### PR TITLE
Improved error handling

### DIFF
--- a/python/conf/search-default.ini
+++ b/python/conf/search-default.ini
@@ -1,8 +1,8 @@
 [Common Args]
 
-outdir      = /home/ece498/cirkopt/python/out
-netlist     = /home/ece498/cirkopt/liberate/netlist/INVX1.sp
-tclscript   = /home/ece498/cirkopt/liberate/tcl/char.tcl
+outdir      = /Users/jamesoliver/code/cirkopt/python/out
+netlist     = /Users/jamesoliver/code/cirkopt/liberate/netlist/INVX1.sp
+tclscript   = /Users/jamesoliver/code/cirkopt/liberate/tcl/char.tcl
 outindex    = [0, 0]
 
 [Search Args]

--- a/python/conf/search-default.ini
+++ b/python/conf/search-default.ini
@@ -1,8 +1,8 @@
 [Common Args]
 
-outdir      = /Users/jamesoliver/code/cirkopt/python/out
-netlist     = /Users/jamesoliver/code/cirkopt/liberate/netlist/INVX1.sp
-tclscript   = /Users/jamesoliver/code/cirkopt/liberate/tcl/char.tcl
+outdir      = /home/ece498/cirkopt/python/out
+netlist     = /home/ece498/cirkopt/liberate/netlist/INVX1.sp
+tclscript   = /home/ece498/cirkopt/liberate/tcl/char.tcl
 outindex    = [0, 0]
 
 [Search Args]

--- a/python/scripts/brute_force_search.py
+++ b/python/scripts/brute_force_search.py
@@ -16,6 +16,7 @@ from src.brute_force_search import (
     Simulator,
 )
 from src.circuit_search_common import Range
+from src.exceptions import CirkoptFileNotFoundError
 
 
 # pylint: disable=too-many-locals
@@ -31,7 +32,7 @@ def brute_force_search(
     simulations_per_iteration: int,
 ):
     if not os.path.isfile(reference_netlist_path):
-        raise FileNotFoundError(reference_netlist_path)
+        raise CirkoptFileNotFoundError(reference_netlist_path)
 
     if not os.path.isdir(out_dir):
         info(f"Creating output directory {out_dir}")

--- a/python/scripts/cirkopt.py
+++ b/python/scripts/cirkopt.py
@@ -331,6 +331,7 @@ class Cirkopt:
             search()
             return
 
+        # pylint: disable=broad-except
         try:
             search()
         except CirkoptException as ex:

--- a/python/scripts/cirkopt.py
+++ b/python/scripts/cirkopt.py
@@ -9,6 +9,7 @@ from random import randint
 from typing import Type, TypeVar
 from textwrap import dedent
 from decimal import Decimal
+from functools import partial
 
 import numpy as np
 import configargparse  # type: ignore
@@ -24,7 +25,7 @@ from scripts.brute_force_search import brute_force_search  # pylint: disable=wro
 from scripts.genetic_search import genetic_search  # pylint: disable=wrong-import-position
 from scripts.single_param_sweep import single_param_sweep  # pylint: disable=wrong-import-position
 from src.circuit_search_common import Param, Range  # pylint: disable=wrong-import-position
-
+from src.exceptions import CirkoptValueError, CirkoptException  # pylint: disable=wrong-import-position
 
 RangeType = TypeVar("RangeType", int, Decimal)
 
@@ -32,7 +33,7 @@ RangeType = TypeVar("RangeType", int, Decimal)
 def _range(param: Param, _type: Type[RangeType], string: str) -> Range[RangeType]:
     params = string.split(":")
     if len(params) != 3:
-        raise ValueError("Range should be formatted as low:step_size:high (inclusive")
+        raise CirkoptValueError("Range should be formatted as low:step_size:high (inclusive")
     low, step_size, high = tuple(map(_type, params))
     return Range(param, low, high, step_size)
 
@@ -64,7 +65,7 @@ def _add_common_args(parser: configargparse.ArgumentParser):
     )
     parser.add_argument(
         "--debug",
-        help="Print lots of debugging statements",
+        help="Print lots of debugging statements. Also does not catch known exceptions.",
         action="store_const",
         dest="loglevel",
         const=DEBUG,
@@ -185,7 +186,11 @@ class Cirkopt:
         # TWO argvs, ie the command (cirkopt) and the subcommand (explore)
         args = parser.parse_args(sys.argv[2:])
 
-        _init_logger(args.loglevel, args.outdir)
+        try:
+            _init_logger(args.loglevel, args.outdir)
+        except FileNotFoundError:
+            error("Could not find or create out directory, please make sure outdir arg is correct.")
+            return
 
         # Print all the arguments given
         for key in args.__dict__:
@@ -289,13 +294,18 @@ class Cirkopt:
         # TWO argvs, ie the command (cirkopt) and the subcommand (explore)
         args = parser.parse_args(sys.argv[2:])
 
-        _init_logger(args.loglevel, args.outdir)
+        try:
+            _init_logger(args.loglevel, args.outdir)
+        except FileNotFoundError:
+            error("Could not find or create out directory, please make sure outdir arg is correct.")
+            return
 
         # Print all the arguments given
         for key in args.__dict__:
             debug(f"{key:<10}: {args.__dict__[key]}")
 
-        genetic_search(
+        search = partial(
+            genetic_search,
             reference_netlist_path=args.netlist,
             max_iterations=args.iterations,
             num_individuals=args.individuals,
@@ -315,6 +325,19 @@ class Cirkopt:
             initial_candidates=args.initial_candidates,
             cache_size=args.cache_size
         )
+
+        # If on debug, don't catch exceptions
+        if args.loglevel == DEBUG:
+            search()
+            return
+
+        try:
+            search()
+        except CirkoptException as ex:
+            error(f"Encountered user error:\n\t{ex}.\nPlease correct the issue and try again.")
+        except Exception as ex:
+            error(f"Encountered unknown error:\n\t{ex}.\n"
+                  f"Please report this as an issue to https://github.com/thrile/cirkopt")
 
     # pylint: disable=no-self-use
     def brute_force(self):
@@ -353,7 +376,11 @@ class Cirkopt:
         # TWO argvs, ie the command (cirkopt) and the subcommand (explore)
         args = parser.parse_args(sys.argv[2:])
 
-        _init_logger(args.loglevel, args.outdir)
+        try:
+            _init_logger(args.loglevel, args.outdir)
+        except FileNotFoundError:
+            error("Could not find or create out directory, please make sure outdir arg is correct.")
+            return
 
         # Print all the arguments given
         for key in args.__dict__:

--- a/python/scripts/genetic_search.py
+++ b/python/scripts/genetic_search.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 
 import matplotlib.pyplot as plt  # type: ignore
 
+from src.exceptions import CirkoptValueError
 from src.circuit_search_common import Range
 from src.file_io import File
 from src.netlist import BaseNetlistFile, Netlist
@@ -48,17 +49,20 @@ def genetic_search(
         info(f"Creating output directory {out_dir}")
         os.mkdir(out_dir)
 
+    if max_iterations < 1:
+        raise CirkoptValueError("Number of iterations must be at least 1")
+
     if num_individuals < 2:
-        raise ValueError("Number of individuals must be at least 2")
+        raise CirkoptValueError("Number of individuals must be at least 2")
 
     if not 0 < alpha < 1:
-        raise ValueError("alpha should be strictly between 0 and 1")
+        raise CirkoptValueError("alpha should be strictly between 0 and 1")
 
     if not 0 < pmutation < 1:
-        raise ValueError("pmutation should be strictly between 0 and 1")
+        raise CirkoptValueError("pmutation should be strictly between 0 and 1")
 
     if mutation_std_deviation <= 0:
-        raise ValueError("mutation_std_deviation should be greater than 0")
+        raise CirkoptValueError("mutation_std_deviation should be greater than 0")
 
     simulator: Simulator = partial(
         liberate_simulator,

--- a/python/scripts/genetic_search.py
+++ b/python/scripts/genetic_search.py
@@ -7,7 +7,7 @@ from decimal import Decimal
 
 import matplotlib.pyplot as plt  # type: ignore
 
-from src.exceptions import CirkoptValueError
+from src.exceptions import CirkoptValueError, CirkoptFileNotFoundError
 from src.circuit_search_common import Range
 from src.file_io import File
 from src.netlist import BaseNetlistFile, Netlist
@@ -43,7 +43,7 @@ def genetic_search(
     cache_size: int
 ):
     if not os.path.isfile(reference_netlist_path):
-        raise FileNotFoundError(reference_netlist_path)
+        raise CirkoptFileNotFoundError(reference_netlist_path)
 
     if not os.path.isdir(out_dir):
         info(f"Creating output directory {out_dir}")

--- a/python/scripts/single_param_sweep.py
+++ b/python/scripts/single_param_sweep.py
@@ -3,6 +3,7 @@ from typing import Union, Sequence, Tuple
 from logging import info
 from functools import partial
 
+from src.exceptions import CirkoptFileNotFoundError
 from src.circuit_search_common import Param
 from src.file_io import File
 from src.liberate_grapher import graph_cell_delay
@@ -27,7 +28,7 @@ def single_param_sweep(
     out_dir: str,
 ):
     if not os.path.isfile(reference_netlist):
-        raise FileNotFoundError(reference_netlist)
+        raise CirkoptFileNotFoundError(reference_netlist)
 
     if not os.path.isdir(out_dir):
         info(f"Creating output directory {out_dir}")

--- a/python/src/circuit_search_common.py
+++ b/python/src/circuit_search_common.py
@@ -4,6 +4,9 @@ from typing import Generic, Iterator, TypeVar
 
 from dataclasses import dataclass
 
+from src.exceptions import CirkoptValueError
+
+
 T = TypeVar('T', Decimal, int)
 
 
@@ -25,16 +28,16 @@ class Range(Generic[T]):
 
     def __post_init__(self):
         if self.low > self.high:
-            raise ValueError("Range low must be less than or equal to high")
+            raise CirkoptValueError("Range low must be less than or equal to high")
 
         if len({type(self.low), type(self.high), type(self.step_size)}) != 1:
-            raise ValueError("Range low, high, and step size must be the same type")
+            raise CirkoptValueError("Range low, high, and step size must be the same type")
 
         if self.param in {Param.WIDTH, Param.LENGTH} and not isinstance(self.low, Decimal):
-            raise ValueError("Widths should be specified as decimals")
+            raise CirkoptValueError("Widths should be specified as decimals")
 
         if self.param == Param.FINGERS and not isinstance(self.low, int):
-            raise ValueError("Fingers should be specified as ints")
+            raise CirkoptValueError("Fingers should be specified as ints")
 
     def __iter__(self) -> Iterator[T]:
         current = self.low

--- a/python/src/exceptions.py
+++ b/python/src/exceptions.py
@@ -1,0 +1,6 @@
+class CirkoptException(Exception):
+    pass
+
+
+class CirkoptValueError(ValueError, CirkoptException):
+    pass

--- a/python/src/exceptions.py
+++ b/python/src/exceptions.py
@@ -4,3 +4,11 @@ class CirkoptException(Exception):
 
 class CirkoptValueError(ValueError, CirkoptException):
     pass
+
+
+class CirkoptFileNotFoundError(FileNotFoundError, CirkoptException):
+    pass
+
+
+class CirkoptNotADirectoryError(NotADirectoryError, CirkoptException):
+    pass

--- a/python/src/file_io.py
+++ b/python/src/file_io.py
@@ -3,6 +3,9 @@ from dataclasses import dataclass
 from abc import ABC, abstractmethod
 
 
+from src.exceptions import CirkoptFileNotFoundError
+
+
 @dataclass(eq=True, unsafe_hash=True)  # Force __hash__() generation
 class FileData:
     _path: str = ""
@@ -41,7 +44,7 @@ class File(IFile):
 
     def read(self) -> str:
         if not os.path.isfile(self._path):
-            raise FileNotFoundError(self.path)
+            raise CirkoptFileNotFoundError(self.path)
         with open(self._path, "r") as reader:
             file_str = reader.read()
         return file_str

--- a/python/src/genetic_search.py
+++ b/python/src/genetic_search.py
@@ -22,6 +22,7 @@ from src.search_algorithm import (
     CostFunction,
 )
 from src.file_io import File
+from src.exceptions import CirkoptValueError
 
 
 @dataclass(frozen=True)
@@ -136,7 +137,7 @@ class GeneticCandidateGenerator(CandidateGenerator[Netlist]):
         ]
 
         if npoints > len(variable_indices):
-            raise ValueError(
+            raise CirkoptValueError(
                 "npoints should be less than or equal to the number of number of devices per "
                 "netlist * number of params the algorithm can vary. "
                 "For example if the algorithm can very length and width for an inverter, nppoints <= 4"

--- a/python/src/liberate.py
+++ b/python/src/liberate.py
@@ -15,6 +15,7 @@ from src.file_io import File
 from src.liberty_parser import LibertyParser, LibertyResult
 from src.netlist import Netlist
 from src.cirkopt_json import ObjectEncoder
+from src.exceptions import CirkoptFileNotFoundError, CirkoptNotADirectoryError
 
 LIBERATE_DEFAULT_CMD: str = "liberate"
 
@@ -63,9 +64,9 @@ def _run_liberate(
     # TODO: Run setup script before
 
     if not os.path.isfile(tcl_script):
-        raise FileNotFoundError(tcl_script)
+        raise CirkoptFileNotFoundError(tcl_script)
     if not os.path.isdir(liberate_dir):
-        raise NotADirectoryError(liberate_dir)
+        raise CirkoptNotADirectoryError(liberate_dir)
     if shutil.which(liberate_cmd) is None:
         error(
             f"'{liberate_cmd}' does not appear to be an executable, "

--- a/python/src/liberty_parser.py
+++ b/python/src/liberty_parser.py
@@ -6,6 +6,7 @@ import pyparsing as pp  # type: ignore
 from pyparsing import pyparsing_common as ppc
 
 from src.file_io import IFile
+from src.exceptions import CirkoptException
 
 
 @dataclass(frozen=True)
@@ -41,7 +42,7 @@ def _to_multi_dict(input_string: str, location: int, toks: List[Any]) -> List[An
 
         # Error if attribute's name has already been defined group name
         if is_attribute and existing_member_is_list_of_dicts:
-            raise Exception(
+            raise CirkoptException(
                 f"Member name '{member_name}' already defined as group name"
             )
 
@@ -51,7 +52,7 @@ def _to_multi_dict(input_string: str, location: int, toks: List[Any]) -> List[An
             and existing_member is not None
             and not existing_member_is_list_of_dicts
         ):
-            raise Exception(
+            raise CirkoptException(
                 f"Group with group name '{member_name}' already defined as attribute"
             )
 
@@ -70,7 +71,7 @@ def _to_multi_dict(input_string: str, location: int, toks: List[Any]) -> List[An
         elif is_group:
             group[member_name] = [member[2]]
         else:
-            raise Exception(f"Unexpected tokens in group: {toks}")
+            raise CirkoptException(f"Unexpected tokens in group: {toks}")
 
     toks[0][-1] = group
     return toks

--- a/python/src/liberty_parser.py
+++ b/python/src/liberty_parser.py
@@ -17,6 +17,7 @@ class Group:
 
 LibertyResult = Group  # Alias for use outside module
 
+
 # pylint: disable=unused-argument
 def _to_multi_dict(input_string: str, location: int, toks: List[Any]) -> List[Any]:
     tokens = toks[0]
@@ -154,6 +155,10 @@ class LibertyParser:
         def dict_to_group(adict: Dict) -> Group:
             return Group({key: handle_value(val) for key, val in adict.items()})
 
-        root = self.liberty_object.parseString(file.read())[0][2]
+        try:
+            root = self.liberty_object.parseString(file.read())[0][2]
+        except Exception as ex:
+            raise CirkoptException(f"Could not parse liberate LDB file at '{file.path()}' because:\n\t{ex}") from ex
+
         result: LibertyResult = dict_to_group(root)
         return result

--- a/python/src/netlist.py
+++ b/python/src/netlist.py
@@ -8,9 +8,12 @@ from src.search_algorithm import CandidateClass
 
 
 SUBCIRKT_NAME_REGEX = r".subckt\s+(.*?)\s+"
-WIDTH_REGEX = r"W=(.*?)\s"
-LENGTH_REGEX = r"L=(.*?)\s"
-FINGERS_REGEX = r"M=(.*?)\s"
+# 1 or more digits, optionally followed by a '.' with one or more digits optionally followed by '+' or '-'
+# followed by e and one or more digits
+SCI_NOTATION = r"(\d+(?:\.\d+)?e[-\+]?\d+)"
+WIDTH_REGEX = r"W=" + SCI_NOTATION
+LENGTH_REGEX = r"L=" + SCI_NOTATION
+FINGERS_REGEX = r"M=(\d+)"
 
 ReturnType = TypeVar("ReturnType")
 
@@ -84,12 +87,16 @@ class Netlist(CandidateClass):
         device_fingers: Optional[Tuple[int, ...]] = None,
     ) -> "Netlist":
         netlist_str = base_netlist_file.contents()
+        if len(netlist_str.strip(" \n")) < 1:
+            raise Exception("Empty netlist file")
 
         if cell_name is None:
             cell_name = _extract(netlist_str, SUBCIRKT_NAME_REGEX, str)
 
         lines = netlist_str.split("\n")
         device_lines = [l + " " for l in lines if len(l) > 0 and l[0].isalpha()]
+        if len(device_lines) < 1:
+            raise Exception("Invalid netlist, no device lines found")
 
         if device_widths is None:
             device_widths = tuple(_extract(l, WIDTH_REGEX, float) for l in device_lines)
@@ -120,6 +127,10 @@ class Netlist(CandidateClass):
         if device_fingers is None:
             device_fingers = self.device_fingers
 
+        # Ensure we're creating valid netlists
+        assert len(cell_name) > 0
+        assert len(device_widths) > 0 and len(device_lengths) > 0 and len(device_fingers) > 0
+
         return Netlist.create(
             base_netlist_file=self.base_netlist_file,
             cell_name=cell_name,
@@ -141,21 +152,21 @@ class Netlist(CandidateClass):
 
         current_device = 0
         for i in range(len(lines)):
-            device_line = lines[i] + " "
+            device_line = lines[i]
             if len(device_line) == 0 or not device_line[0].isalpha():
                 continue
 
             device_line = _replace(
-                regex=WIDTH_REGEX, new=f"W={self.device_widths[current_device]} ", text=device_line
+                regex=WIDTH_REGEX, new=f"W={self.device_widths[current_device]}", text=device_line
             )
             device_line = _replace(
                 regex=LENGTH_REGEX,
-                new=f"L={self.device_lengths[current_device]} ",
+                new=f"L={self.device_lengths[current_device]}",
                 text=device_line,
             )
             device_line = _replace(
                 regex=FINGERS_REGEX,
-                new=f"M={self.device_fingers[current_device]} ",
+                new=f"M={self.device_fingers[current_device]}",
                 text=device_line,
             )
 

--- a/python/src/netlist.py
+++ b/python/src/netlist.py
@@ -5,6 +5,7 @@ from typing import Optional, Tuple, Type, TypeVar, Any
 
 from src.file_io import IFile as File
 from src.search_algorithm import CandidateClass
+from src.exceptions import CirkoptValueError, CirkoptException
 
 
 SUBCIRKT_NAME_REGEX = r".subckt\s+(.*?)\s+"
@@ -23,7 +24,7 @@ def _extract(text: str, regex: str, return_type: Type[ReturnType]) -> ReturnType
     if match:
         str_value = match.group(1)
         return return_type(str_value)  # type: ignore
-    raise ValueError(f"No match of {regex} found in {text}")
+    raise CirkoptValueError(f"No match of {regex} found in {text}")
 
 
 def _replace(regex: str, new: str, text: str) -> str:
@@ -88,7 +89,7 @@ class Netlist(CandidateClass):
     ) -> "Netlist":
         netlist_str = base_netlist_file.contents()
         if len(netlist_str.strip(" \n")) < 1:
-            raise Exception("Empty netlist file")
+            raise CirkoptException("Empty netlist file")
 
         if cell_name is None:
             cell_name = _extract(netlist_str, SUBCIRKT_NAME_REGEX, str)
@@ -96,7 +97,7 @@ class Netlist(CandidateClass):
         lines = netlist_str.split("\n")
         device_lines = [l + " " for l in lines if len(l) > 0 and l[0].isalpha()]
         if len(device_lines) < 1:
-            raise Exception("Invalid netlist, no device lines found")
+            raise CirkoptException("Invalid netlist, no device lines found")
 
         if device_widths is None:
             device_widths = tuple(_extract(l, WIDTH_REGEX, float) for l in device_lines)

--- a/python/src/netlist_cost_functions.py
+++ b/python/src/netlist_cost_functions.py
@@ -4,6 +4,7 @@ from itertools import chain
 from src.search_algorithm import CostMap
 from src.netlist import Netlist
 from src.liberty_parser import LibertyResult, Group
+from src.exceptions import CirkoptValueError
 
 
 def noop_cost_function(
@@ -51,7 +52,7 @@ def delay_cost_function(
     for candidate in candidates:
         if candidate.key() not in cost_map:
             missing = {candidate.key() for candidate in candidates} - cost_map.keys()
-            raise ValueError(
+            raise CirkoptValueError(
                 f"Not all candidates have a simulation result: {missing}, {cost_map.keys()}"
             )
 

--- a/python/src/quantize.py
+++ b/python/src/quantize.py
@@ -2,6 +2,8 @@ from decimal import Decimal, ROUND_UP, ROUND_HALF_EVEN, ROUND_DOWN
 
 from enum import Enum
 
+from src.exceptions import CirkoptValueError
+
 
 class Rounding(Enum):
     UP = 1
@@ -16,7 +18,7 @@ def quantize(
         rounding: Rounding = Rounding.TIE_EVEN
 ) -> int:
     if precision <= 0:
-        raise ValueError("Precision cannot be 0")
+        raise CirkoptValueError("Precision cannot be 0")
 
     quantized = (val - _min).max(Decimal(0.0)) / precision
 
@@ -27,7 +29,7 @@ def quantize(
     elif rounding == Rounding.UP:
         decimal_rounding = ROUND_UP
     else:
-        raise ValueError("rounding not one of UP, DOWN, or TIE_EVEN")
+        raise CirkoptValueError("rounding not one of UP, DOWN, or TIE_EVEN")
 
     return int(quantized.quantize(Decimal('1.'), rounding=decimal_rounding))
 
@@ -35,5 +37,5 @@ def quantize(
 def scale(val: int, precision: Decimal) -> float:
     precision = Decimal(precision)
     if precision <= 0:
-        raise ValueError("Precision cannot be 0")
+        raise CirkoptValueError("Precision cannot be 0")
     return float(val * precision)

--- a/python/src/utils.py
+++ b/python/src/utils.py
@@ -1,6 +1,8 @@
 from itertools import islice
 from typing import Callable, Iterable, Iterator, Sequence, TypeVar
 
+from src.exceptions import CirkoptException
+
 
 T = TypeVar('T')
 
@@ -8,9 +10,9 @@ T = TypeVar('T')
 def single(predicate: Callable[[T], bool], seq: Sequence[T]) -> T:
     matches = list(filter(predicate, seq))
     if len(matches) == 0:
-        raise Exception('Zero items in sequence match predicate')
+        raise CirkoptException('Zero items in sequence match predicate')
     if len(matches) > 1:
-        raise Exception('More than one item in sequence matches predicate')
+        raise CirkoptException('More than one item in sequence matches predicate')
     return matches[0]
 
 

--- a/python/tests/test_circuit_search_common.py
+++ b/python/tests/test_circuit_search_common.py
@@ -2,16 +2,17 @@ from decimal import Decimal
 import unittest
 
 from src.circuit_search_common import Range, Param
+from src.exceptions import CirkoptValueError
 
 
 class TestCircuitSearchCommon(unittest.TestCase):
 
     def test_range(self):
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaises(CirkoptValueError) as context:
             Range(Param.WIDTH, Decimal(2.0), Decimal(1.0), Decimal(1.0))
         self.assertIn("Range low must be less than or equal to high", context.exception.args)
 
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaises(CirkoptValueError) as context:
             Range(Param.WIDTH, 1, 2.0, 1.0)
         self.assertIn("Range low, high, and step size must be the same type", context.exception.args)
 

--- a/python/tests/test_circuit_search_common.py
+++ b/python/tests/test_circuit_search_common.py
@@ -9,11 +9,11 @@ class TestCircuitSearchCommon(unittest.TestCase):
     def test_range(self):
         with self.assertRaises(ValueError) as context:
             Range(Param.WIDTH, Decimal(2.0), Decimal(1.0), Decimal(1.0))
-            self.assertIn("Range low must be less than or equal to high", context.exception.args)
+        self.assertIn("Range low must be less than or equal to high", context.exception.args)
 
         with self.assertRaises(ValueError) as context:
             Range(Param.WIDTH, 1, 2.0, 1.0)
-            self.assertIn("Range low and high must be the same type", context.exception.args)
+        self.assertIn("Range low, high, and step size must be the same type", context.exception.args)
 
         self.assertEqual(list(Range(Param.FINGERS, 1, 6, 1)), [1, 2, 3, 4, 5, 6])
         self.assertEqual(list(Range(Param.FINGERS, 1, 6, 2)), [1, 3, 5])

--- a/python/tests/test_json.py
+++ b/python/tests/test_json.py
@@ -4,6 +4,7 @@ import json
 from src.cirkopt_json import ObjectEncoder
 from src.file_io import MockFile, IFile
 from src.netlist import Netlist, BaseNetlistFile
+from tests.netlist_example import TEST_NETLIST
 
 JSON_MOCK_FILE = r"""{"__MockFile__": true, "_path": "/path/to/file", "_contents": ""}"""
 
@@ -18,7 +19,7 @@ JSON_NETLIST = r"""{
     "base_netlist_file": {
         "__BaseNetlistFile__": true,
         "_path": "",
-        "_contents": ""
+        "_contents": """ + json.dumps(TEST_NETLIST) + r"""
     },
     "cell_name": "Cell Name",
     "device_widths": [
@@ -64,8 +65,10 @@ class TestJSON(unittest.TestCase):
             base_netlist_file,
         )
 
+        mock_file = MockFile()
+        mock_file.write(TEST_NETLIST)
         netlist = Netlist.create(
-            base_netlist_file=BaseNetlistFile.create(MockFile()),
+            base_netlist_file=BaseNetlistFile.create(mock_file),
             cell_name="Cell Name",
             device_widths=tuple([1, 3.0, 5.5]),
             device_lengths=tuple([0]),

--- a/python/tests/test_liberty_parser.py
+++ b/python/tests/test_liberty_parser.py
@@ -2,6 +2,7 @@ import unittest
 
 from src.liberty_parser import LibertyParser
 from src.file_io import MockFile
+from src.exceptions import CirkoptException
 from tests.liberty_example import LIBERTY_EXAMPLE
 
 
@@ -93,7 +94,7 @@ class TestLibertyParser(unittest.TestCase):
 
         parser = LibertyParser()
 
-        with self.assertRaises(Exception) as context:
+        with self.assertRaises(CirkoptException) as context:
             parser.parse(mock_file)
 
         self.assertIn(
@@ -115,7 +116,7 @@ class TestLibertyParser(unittest.TestCase):
 
         parser = LibertyParser()
 
-        with self.assertRaises(Exception) as context:
+        with self.assertRaises(CirkoptException) as context:
             parser.parse(mock_file)
 
         self.assertIn(

--- a/python/tests/test_liberty_parser.py
+++ b/python/tests/test_liberty_parser.py
@@ -98,7 +98,8 @@ class TestLibertyParser(unittest.TestCase):
             parser.parse(mock_file)
 
         self.assertIn(
-            "Group with group name 'comment' already defined as attribute",
+            "Could not parse liberate LDB file at '' because:"
+            "\n\tGroup with group name 'comment' already defined as attribute",
             context.exception.args,
         )
 
@@ -120,6 +121,7 @@ class TestLibertyParser(unittest.TestCase):
             parser.parse(mock_file)
 
         self.assertIn(
-            "Member name 'comment' already defined as group name",
+            "Could not parse liberate LDB file at '' because:"
+            "\n\tMember name 'comment' already defined as group name",
             context.exception.args,
         )

--- a/python/tests/test_netlist.py
+++ b/python/tests/test_netlist.py
@@ -4,6 +4,7 @@ from dataclasses import FrozenInstanceError
 
 from src.netlist import BaseNetlistFile, Netlist
 from src.file_io import MockFile
+from src.exceptions import CirkoptException
 from tests.netlist_example import TEST_NETLIST
 
 
@@ -15,7 +16,7 @@ class TestNetlist(unittest.TestCase):
         """
 
         mock_file.write(textwrap.dedent(netlist_blank))
-        with self.assertRaises(Exception) as context:
+        with self.assertRaises(CirkoptException) as context:
             Netlist.create(BaseNetlistFile.create(mock_file))
         self.assertIn("Empty netlist file", context.exception.args)
 
@@ -32,7 +33,7 @@ class TestNetlist(unittest.TestCase):
         """
 
         mock_file.write(textwrap.dedent(netlist_no_devices))
-        with self.assertRaises(Exception) as context:
+        with self.assertRaises(CirkoptException) as context:
             Netlist.create(BaseNetlistFile.create(mock_file))
         self.assertIn("Invalid netlist, no device lines found", context.exception.args)
 
@@ -49,7 +50,7 @@ class TestNetlist(unittest.TestCase):
             .ends INVX1_4
         """
         mock_file.write(textwrap.dedent(netlist_no_width))
-        with self.assertRaises(Exception) as context:
+        with self.assertRaises(CirkoptException) as context:
             Netlist.create(BaseNetlistFile.create(mock_file))
         expected_prefix = "No match of W=(\\d+(?:\\.\\d+)?e[-\\+]?\\d+) found in mp0 "
         self.assertTrue(context.exception.args[0].startswith(expected_prefix))

--- a/python/tests/test_netlist.py
+++ b/python/tests/test_netlist.py
@@ -8,6 +8,52 @@ from tests.netlist_example import TEST_NETLIST
 
 
 class TestNetlist(unittest.TestCase):
+    def test_invalid_netlists(self):
+        mock_file = MockFile()
+        netlist_blank = """
+            
+        """
+
+        mock_file.write(textwrap.dedent(netlist_blank))
+        with self.assertRaises(Exception) as context:
+            Netlist.create(BaseNetlistFile.create(mock_file))
+        self.assertIn("Empty netlist file", context.exception.args)
+
+
+        netlist_no_devices = """
+            ** Library name: gsclib045
+            ** Cell name: INVX1_4
+            ** View name: schematic
+            .subckt INVX1_4 A Y VDD VSS
+            *.PININFO  VSS:I VDD:I A:I Y:O
+            ** Above line required by Conformal LEC - DO NOT DELETE
+
+            .ends INVX1_4
+        """
+
+        mock_file.write(textwrap.dedent(netlist_no_devices))
+        with self.assertRaises(Exception) as context:
+            Netlist.create(BaseNetlistFile.create(mock_file))
+        self.assertIn("Invalid netlist, no device lines found", context.exception.args)
+
+        netlist_no_width = """
+            ** Library name: gsclib045
+            ** Cell name: INVX1_4
+            ** View name: schematic
+            .subckt INVX1_4 A Y VDD VSS
+            *.PININFO  VSS:I VDD:I A:I Y:O
+            ** Above line required by Conformal LEC - DO NOT DELETE
+            
+            mp0 Y A VDD VDD g45p1svt L=5e-08 AD=54.6e-15 AS=54.6e-15 PD=1.06e-6 PS=1.06e-6 NRD=358.974e-3 NRS=358.974e-3 M=2
+            mn0 Y A VSS VSS g45n1svt L=6e-08 AD=36.4e-15 AS=36.4e-15 PD=800e-9 PS=800e-9 NRD=538.462e-3 NRS=538.462e-3 M=3
+            .ends INVX1_4
+        """
+        mock_file.write(textwrap.dedent(netlist_no_width))
+        with self.assertRaises(Exception) as context:
+            Netlist.create(BaseNetlistFile.create(mock_file))
+        expected_prefix = "No match of W=(\\d+(?:\\.\\d+)?e[-\\+]?\\d+) found in mp0 "
+        self.assertTrue(context.exception.args[0].startswith(expected_prefix))
+
     def test_base_netlist_file(self):
         mock_file = MockFile()
         mock_file.write("some content")
@@ -26,6 +72,48 @@ class TestNetlist(unittest.TestCase):
         self.assertEqual(netlist.device_widths, (250e-9, 300e-9))
         self.assertEqual(netlist.device_lengths, (45e-9, 50e-9))
         self.assertEqual(netlist.device_fingers, (1, 2))
+
+    def test_read_write_netlist_different_format(self):
+        # Differences: M and W have switched place, L and W have one value with decimal and one without
+        # L and W have one value 0 padded exponent, second line ends with a extra space
+        netlist_string = """
+            ** Library name: gsclib045
+            ** Cell name: INVX1_4
+            ** View name: schematic
+            .subckt INVX1_4 A Y VDD VSS
+            *.PININFO  VSS:I VDD:I A:I Y:O
+            ** Above line required by Conformal LEC - DO NOT DELETE
+
+            mp0 Y A VDD VDD g45p1svt L=5.65e-8 M=2 AD=54.6e-15 AS=54.6e-15 PD=1.06e-6 PS=1.06e-6 NRD=358.974e-3 NRS=358.974e-3 W=2.6e-07
+            mn0 Y A VSS VSS g45n1svt L=6e-08 M=3 AD=36.4e-15 AS=36.4e-15 PD=800e-9 PS=800e-9 NRD=538.462e-3 NRS=538.462e-3 W=2e-7 
+            .ends INVX1_4
+        """
+        mock_file = MockFile()
+        mock_file.write(textwrap.dedent(netlist_string))
+        netlist = Netlist.create(BaseNetlistFile.create(mock_file))
+
+        self.assertEqual(netlist.cell_name, "INVX1_4")
+        self.assertEqual(netlist.device_lengths, (5.65e-8, 6e-8))
+        self.assertEqual(netlist.device_widths, (2.6e-7, 2e-7))
+        self.assertEqual(netlist.device_fingers, (2, 3))
+
+        mock_file.write("")  # reusing mock file
+        netlist.persist(mock_file)
+        # python adds 0 padding to exponents
+        expected_file = """
+            ** Library name: gsclib045
+            ** Cell name: INVX1_4
+            ** View name: schematic
+            .subckt INVX1_4 A Y VDD VSS
+            *.PININFO  VSS:I VDD:I A:I Y:O
+            ** Above line required by Conformal LEC - DO NOT DELETE
+            
+            mp0 Y A VDD VDD g45p1svt L=5.65e-08 M=2 AD=54.6e-15 AS=54.6e-15 PD=1.06e-6 PS=1.06e-6 NRD=358.974e-3 NRS=358.974e-3 W=2.6e-07
+            mn0 Y A VSS VSS g45n1svt L=6e-08 M=3 AD=36.4e-15 AS=36.4e-15 PD=800e-9 PS=800e-9 NRD=538.462e-3 NRS=538.462e-3 W=2e-07
+            .ends INVX1_4
+        """
+        self.assertEqual(textwrap.dedent(expected_file), mock_file.read())
+
 
     def test_write_netlist_values(self):
         mock_file = MockFile()

--- a/python/tests/test_quantize.py
+++ b/python/tests/test_quantize.py
@@ -2,15 +2,16 @@ import unittest
 from decimal import Decimal as d
 
 from src.quantize import quantize, scale, Rounding
+from src.exceptions import CirkoptValueError
 
 
 class TestQuantize(unittest.TestCase):
 
     def test_quantize(self):
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaises(CirkoptValueError) as context:
             quantize(d(1.0), d('0'))
         self.assertIn("Precision cannot be 0", context.exception.args)
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaises(CirkoptValueError) as context:
             quantize(d(1.0), d('-0.1'))
         self.assertIn("Precision cannot be 0", context.exception.args)
 
@@ -35,10 +36,10 @@ class TestQuantize(unittest.TestCase):
         self.assertEqual(quantize(d(1.24e-9), d('0.5e-9')), 2)
 
     def test_scale(self):
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaises(CirkoptValueError) as context:
             scale(1, '0')
         self.assertIn("Precision cannot be 0", context.exception.args)
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaises(CirkoptValueError) as context:
             scale(1, '-0.1')
         self.assertIn("Precision cannot be 0", context.exception.args)
 

--- a/python/tests/test_quantize.py
+++ b/python/tests/test_quantize.py
@@ -9,10 +9,10 @@ class TestQuantize(unittest.TestCase):
     def test_quantize(self):
         with self.assertRaises(ValueError) as context:
             quantize(d(1.0), d('0'))
-            self.assertIn("Precision cannot be less than or equal to 0", context.exception.args)
+        self.assertIn("Precision cannot be 0", context.exception.args)
         with self.assertRaises(ValueError) as context:
             quantize(d(1.0), d('-0.1'))
-            self.assertIn("Precision cannot be less than or equal to 0", context.exception.args)
+        self.assertIn("Precision cannot be 0", context.exception.args)
 
         self.assertEqual(quantize(d(0.1), d('1.0')), 0)
         self.assertEqual(quantize(d(1.0), d('1.0')), 1)
@@ -37,10 +37,10 @@ class TestQuantize(unittest.TestCase):
     def test_scale(self):
         with self.assertRaises(ValueError) as context:
             scale(1, '0')
-            self.assertIn("Precision cannot be less than or equal to 0", context.exception.args)
+        self.assertIn("Precision cannot be 0", context.exception.args)
         with self.assertRaises(ValueError) as context:
             scale(1, '-0.1')
-            self.assertIn("Precision cannot be less than or equal to 0", context.exception.args)
+        self.assertIn("Precision cannot be 0", context.exception.args)
 
         self.assertEqual(scale(0, '1.0'), 0)
         self.assertEqual(scale(1, '1.0'), 1.0)

--- a/python/tests/test_utils.py
+++ b/python/tests/test_utils.py
@@ -8,11 +8,11 @@ class TestUtils(unittest.TestCase):
     def test_single(self):
         with self.assertRaises(Exception) as context:
             single(lambda it: True, [])
-            self.assertIn("Zero items in sequence match predicate", context.exception.args)
+        self.assertIn("Zero items in sequence match predicate", context.exception.args)
 
         with self.assertRaises(Exception) as context:
             single(lambda it: True, [0, 0])
-            self.assertIn("More than one item in sequence matches predicate", context.exception.args)
+        self.assertIn("More than one item in sequence matches predicate", context.exception.args)
 
         self.assertEqual(single(lambda it: it == 0, range(10)), 0)
 

--- a/python/tests/test_utils.py
+++ b/python/tests/test_utils.py
@@ -1,16 +1,17 @@
 import unittest
 
 from src.utils import single, chunked
+from src.exceptions import CirkoptException
 
 
 class TestUtils(unittest.TestCase):
 
     def test_single(self):
-        with self.assertRaises(Exception) as context:
+        with self.assertRaises(CirkoptException) as context:
             single(lambda it: True, [])
         self.assertIn("Zero items in sequence match predicate", context.exception.args)
 
-        with self.assertRaises(Exception) as context:
+        with self.assertRaises(CirkoptException) as context:
             single(lambda it: True, [0, 0])
         self.assertIn("More than one item in sequence matches predicate", context.exception.args)
 


### PR DESCRIPTION
- Improves netlist error handling, added some tests
- Wraps all known exceptional cases in `Cirkopt*Exception` if not in debug mode
  - This allows us to catch all known exceptions at the top so a user just gets a error message. Tells them to fix the issue since we typically raise when its a user error
  - We also catch all exceptions and say to make a github issue lel
 
example:
```
$ pipenv run python -m scripts.cirkopt search --pmutation 1.05
ERROR (11:34:46 AM): Encountered user error:
        pmutation should be strictly between 0 and 1.
Please correct the issue and try again.
```

or with --debug
```
$pipenv run python -m scripts.cirkopt search --pmutation 1.05 --debug
DEBUG (11:34:51 AM): config_file: None
DEBUG (11:34:51 AM): write_out_config_file_to_this_path: None
DEBUG (11:34:51 AM): iterations: 5
DEBUG (11:34:51 AM): individuals: 32
DEBUG (11:34:51 AM): elitism   : True
DEBUG (11:34:51 AM): npoints   : 2
DEBUG (11:34:51 AM): alpha     : 0.5
DEBUG (11:34:51 AM): pmutation : 1.05
DEBUG (11:34:51 AM): mutation_std_dev: 5.0
DEBUG (11:34:51 AM): width     : Range(param=<Param.WIDTH: 1>, low=Decimal('2.00E-7'), high=Decimal('0.000002000'), step_size=Decimal('1.00E-7'))
DEBUG (11:34:51 AM): length    : Range(param=<Param.LENGTH: 2>, low=Decimal('4.5E-8'), high=Decimal('4.5E-8'), step_size=Decimal('1E-9'))
DEBUG (11:34:51 AM): fingers   : Range(param=<Param.FINGERS: 3>, low=1, high=1, step_size=1)
DEBUG (11:34:51 AM): seed      : 2256898964
DEBUG (11:34:51 AM): cache_size: 50
DEBUG (11:34:51 AM): outdir    : /Users/jamesoliver/code/cirkopt/python/out
DEBUG (11:34:51 AM): netlist   : /Users/jamesoliver/code/cirkopt/liberate/netlist/INVX1.sp
DEBUG (11:34:51 AM): tclscript : /Users/jamesoliver/code/cirkopt/liberate/tcl/char.tcl
DEBUG (11:34:51 AM): loglevel  : 10
DEBUG (11:34:51 AM): outindex  : [0, 0]
DEBUG (11:34:51 AM): initial_candidates: None
Traceback (most recent call last):
  File "/usr/local/opt/python/Frameworks/Python.framework/Versions/3.7/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/opt/python/Frameworks/Python.framework/Versions/3.7/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Users/jamesoliver/code/cirkopt/python/scripts/cirkopt.py", line 409, in <module>
    Cirkopt()
  File "/Users/jamesoliver/code/cirkopt/python/scripts/cirkopt.py", line 145, in __init__
    getattr(self, args.command)()
  File "/Users/jamesoliver/code/cirkopt/python/scripts/cirkopt.py", line 331, in search
    search()
  File "/Users/jamesoliver/code/cirkopt/python/scripts/genetic_search.py", line 62, in genetic_search
    raise CirkoptValueError("pmutation should be strictly between 0 and 1")
src.exceptions.CirkoptValueError: pmutation should be strictly between 0 and 1
```

- Fixes a kind of silly testing mistake
```python3
with self.assertRaises(Exception) as ex:
  # bad statement
  self.assertEquals(context.exception.args[0], message)
```
is always true becuase the self.assertEquals is never run. It needs to be placed outside the with block